### PR TITLE
Fix for URL assembly with non-zero metallicities

### DIFF
--- a/expecto/core.py
+++ b/expecto/core.py
@@ -109,16 +109,39 @@ def get_url(T_eff, log_g, Z=0, alpha=0):
     else:
         alpha_sign = '-'
 
+    directory_term = (
+        'Z' + z_sign + '{Z:1.1f}'
+    ).format(
+        Z=abs(closest_grid_Z)
+    )
+
+    metallicity_term = (
+        z_sign + '{Z:1.1f}'
+    ).format(
+        Z=abs(closest_grid_Z)
+    )
+
+    if closest_grid_alpha != 0:
+        alpha_term = (
+            'Alpha=' + alpha_sign + '{alpha:1.2f}'
+        ).format(
+            alpha=abs(closest_grid_alpha)
+        )
+
+        directory_term += '.' + alpha_term
+        metallicity_term += '.' + alpha_term + '.'
+    else:
+        metallicity_term += '.'
+
     url = (
         phoenix_base_url +
-        'Z' + z_sign +
-        '{Z:1.1f}/lte{T_eff:05d}-{log_g:1.2f}' + alpha_sign +
-        '{alpha:1.1f}.PHOENIX-ACES-AGSS-COND-2011-HiRes.fits'
+        directory_term +
+        '/lte{T_eff:05d}-{log_g:1.2f}' +
+        metallicity_term +
+        'PHOENIX-ACES-AGSS-COND-2011-HiRes.fits'
     ).format(
         T_eff=closest_grid_temperature,
         log_g=closest_grid_logg,
-        Z=abs(closest_grid_Z),
-        alpha=closest_grid_alpha
     )
     return url
 

--- a/expecto/tests/test_core.py
+++ b/expecto/tests/test_core.py
@@ -36,3 +36,28 @@ def test_get_spectrum():
         np.log(spectrum.flux[test_mask].value),
         rtol=0.02
     )
+
+
+@pytest.mark.remote_data
+@pytest.mark.parametrize(
+    'params,',
+    [
+        dict(T_eff=3477, log_g=4.833, Z=+0.33, alpha=0),
+        dict(T_eff=3477, log_g=4.833, Z=-0.33, alpha=0.4),
+        dict(T_eff=3477, log_g=4.833, Z=-0.33, alpha=0.8),
+    ]
+)
+def test_metallicity(params):
+    spectrum = get_spectrum(
+        **params
+    )
+
+    # validate that the metadata matches
+    # expectations given the inputs:
+    retrieved_T_eff = spectrum.meta['PHXTEFF']
+    retrieved_Z = spectrum.meta['PHXM_H']
+    retrieved_alpha = spectrum.meta['PHXALPHA']
+
+    assert retrieved_T_eff == np.round(params['T_eff'], -2)
+    assert retrieved_Z == np.round(params['Z'] * 2, 0) / 2
+    assert retrieved_alpha == params['alpha']


### PR DESCRIPTION
@emolter pointed out in #4 that non-zero metallicity is producing faulty queries. This PR fixes the metallicity part of the URL builder, and adds a test to ensure that users can set M/H _and_ alpha.

Closes #4.